### PR TITLE
Add embedding training tool

### DIFF
--- a/src/core/file_manager.py
+++ b/src/core/file_manager.py
@@ -1130,8 +1130,8 @@ class FileManager:
             self.logger.error(f"Error saving debug image: {str(e)}")
             return None
     
-    def save_drill_trace(self, 
-                       image: np.ndarray, 
+    def save_drill_trace(self,
+                       image: np.ndarray,
                        hole_id: str) -> str:
         """
         Save a drill trace image.
@@ -1161,6 +1161,28 @@ class FileManager:
             
         except Exception as e:
             self.logger.error(f"Error saving drill trace image: {str(e)}")
+            return None
+
+    def save_embedding_plot(self, image_path: str, filename: str = "embedding_plot.png") -> Optional[str]:
+        """
+        Save an embedding plot image to the debugging directory.
+
+        Args:
+            image_path: Path to the image file to copy.
+            filename: Desired filename for the saved plot.
+
+        Returns:
+            Path to the saved plot or None if an error occurs.
+        """
+        try:
+            save_dir = self.dir_structure["debugging"]
+            os.makedirs(save_dir, exist_ok=True)
+            dest = os.path.join(save_dir, filename)
+            shutil.copy(image_path, dest)
+            self.logger.info(f"Saved embedding plot: {dest}")
+            return dest
+        except Exception as e:
+            self.logger.error(f"Error saving embedding plot: {str(e)}")
             return None
         
     def save_original_file(self, 

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -20,6 +20,7 @@ from gui.drillhole_trace_designer import DrillholeTraceDesigner
 from gui.logging_review_dialog import LoggingReviewDialog
 from gui.progress_dialog import ProgressDialog
 from gui.widgets.modern_notebook import ModernNotebook
+from gui.embedding_training_dialog import EmbeddingTrainingDialog
 
 
 # Optional: Define __all__ to control what gets imported with from gui import *
@@ -41,6 +42,7 @@ __all__ = [
     'LoggingReviewDialog',
     'ProgressDialog',
     'ModernNotebook',
+    'EmbeddingTrainingDialog',
     'FirstRunDialog',
     'ThemedMenu',
     'ThemedMenuBar'

--- a/src/gui/embedding_training_dialog.py
+++ b/src/gui/embedding_training_dialog.py
@@ -1,0 +1,140 @@
+"""
+GUI dialog for generating embeddings from images and tabular data.
+"""
+
+import os
+import tkinter as tk
+from tkinter import filedialog, ttk
+from typing import List, Tuple
+import pandas as pd
+
+from gui.dialog_helper import DialogHelper
+from processing.embedding_trainer import generate_embeddings, plot_embeddings
+
+
+class EmbeddingTrainingDialog:
+    """Dialog allowing users to select data and generate embeddings."""
+
+    def __init__(self, parent, gui_manager, file_manager):
+        self.parent = parent
+        self.gui_manager = gui_manager
+        self.file_manager = file_manager
+        self.image_folder = None
+        self.csv_path = None
+        self.df_columns: List[str] = []
+        self.column_vars: List[Tuple[str, tk.BooleanVar]] = []
+        self.holeid_var = tk.StringVar()
+        self.depth_var = tk.StringVar()
+
+        self._create_dialog()
+
+    def _create_dialog(self) -> None:
+        self.dialog = DialogHelper.create_dialog(
+            self.parent,
+            DialogHelper.t("Embedding Tool"),
+            modal=True,
+            topmost=True,
+        )
+        self.dialog.configure(bg=self.gui_manager.theme_colors["background"])
+
+        frame = ttk.Frame(self.dialog, padding=10)
+        frame.pack(fill=tk.BOTH, expand=True)
+
+        btn_row = ttk.Frame(frame)
+        btn_row.pack(fill=tk.X, pady=(0, 10))
+
+        self.gui_manager.create_modern_button(
+            btn_row,
+            text="Select Image Folder",
+            color=self.gui_manager.theme_colors["accent_blue"],
+            command=self._select_folder,
+        ).pack(side=tk.LEFT, padx=5)
+
+        self.gui_manager.create_modern_button(
+            btn_row,
+            text="Select CSV File",
+            color=self.gui_manager.theme_colors["accent_blue"],
+            command=self._select_csv,
+        ).pack(side=tk.LEFT, padx=5)
+
+        combo_row = ttk.Frame(frame)
+        combo_row.pack(fill=tk.X, pady=(0, 10))
+
+        self.holeid_combo = ttk.Combobox(combo_row, textvariable=self.holeid_var, state="readonly")
+        self.holeid_combo.pack(side=tk.LEFT, padx=5)
+        self.holeid_combo.set(DialogHelper.t("Hole ID"))
+
+        self.depth_combo = ttk.Combobox(combo_row, textvariable=self.depth_var, state="readonly")
+        self.depth_combo.pack(side=tk.LEFT, padx=5)
+        self.depth_combo.set(DialogHelper.t("Depth"))
+
+        self.checkbox_frame = ttk.LabelFrame(frame, text=DialogHelper.t("Select Input Columns"))
+        self.checkbox_frame.pack(fill=tk.BOTH, expand=True)
+
+        self.gui_manager.create_modern_button(
+            frame,
+            text="Generate Embeddings",
+            color=self.gui_manager.theme_colors["accent_green"],
+            command=self._process,
+        ).pack(pady=10)
+
+    def _select_folder(self) -> None:
+        folder = filedialog.askdirectory(title=DialogHelper.t("Select Image Folder"))
+        if folder:
+            self.image_folder = folder
+
+    def _select_csv(self) -> None:
+        path = filedialog.askopenfilename(title=DialogHelper.t("Select CSV File"), filetypes=[("CSV files", "*.csv")])
+        if not path:
+            return
+        self.csv_path = path
+        df = pd.read_csv(path)
+        self.df_columns = df.columns.tolist()
+        self.holeid_combo["values"] = self.df_columns
+        self.depth_combo["values"] = self.df_columns
+        for widget in self.checkbox_frame.winfo_children():
+            widget.destroy()
+        self.column_vars.clear()
+        for col in self.df_columns:
+            var = tk.BooleanVar()
+            chk = tk.Checkbutton(self.checkbox_frame, text=col, variable=var)
+            chk.pack(anchor="w")
+            self.column_vars.append((col, var))
+
+    def _process(self) -> None:
+        if not (self.image_folder and self.csv_path and self.holeid_var.get() and self.depth_var.get()):
+            DialogHelper.show_message(self.dialog, DialogHelper.t("Error"), DialogHelper.t("Missing inputs"), message_type="error")
+            return
+
+        df = pd.read_csv(self.csv_path)
+        image_files = [os.path.join(self.image_folder, f) for f in os.listdir(self.image_folder) if f.lower().endswith((".png", ".jpg", ".jpeg"))]
+        images = []
+        tabular = []
+        for path in image_files:
+            fname = os.path.basename(path)
+            holeid, depth = self._extract_info(fname)
+            match = df[(df[self.holeid_var.get()] == holeid) & (df[self.depth_var.get()] == depth)]
+            if len(match) == 1:
+                row = match.iloc[0]
+                values = [float(row[col]) for col, var in self.column_vars if var.get()]
+                images.append(path)
+                tabular.append(values)
+
+        if not images:
+            DialogHelper.show_message(self.dialog, DialogHelper.t("Info"), DialogHelper.t("No matches found"), message_type="info")
+            return
+
+        embeddings = generate_embeddings(images, tabular)
+        plot_path = os.path.join(self.file_manager.dir_structure["debugging"], "embedding_plot.png")
+        plot_embeddings(embeddings, plot_path, gui_manager=self.gui_manager)
+        self.file_manager.save_embedding_plot(plot_path)
+        DialogHelper.show_message(self.dialog, DialogHelper.t("Success"), DialogHelper.t("Embedding plot saved"), message_type="info")
+
+    @staticmethod
+    def _extract_info(filename: str) -> Tuple[str, int]:
+        import re
+        match = re.search(r"(.*?)_CC_(\d{3})", filename)
+        if match:
+            return match.group(1), int(match.group(2))
+        return "", -1
+

--- a/src/gui/main_gui.py
+++ b/src/gui/main_gui.py
@@ -17,6 +17,7 @@ from processing.drillhole_trace_generator import DrillholeTraceGenerator
 from gui.widgets import *
 from gui.qaqc_manager import QAQCManager
 from gui.logging_review_dialog import LoggingReviewDialog
+from gui.embedding_training_dialog import EmbeddingTrainingDialog
 from utils.json_register_manager import JSONRegisterManager
 from utils.register_synchronizer import RegisterSynchronizer
 from gui.progress_dialog import ProgressDialog
@@ -700,6 +701,13 @@ class MainGUI:
                 'color': self.gui_manager.theme_colors["accent_blue"],
                 'command': self.on_generate_trace,
                 'icon': "📊"
+            },
+            {
+                'name': 'embedding_button',
+                'text': self.t("Embedding Tool"),
+                'color': self.gui_manager.theme_colors["accent_blue"],
+                'command': self._open_embedding_dialog,
+                'icon': "🧩"
             },
             {
                 'name': 'quit_button',
@@ -2373,6 +2381,19 @@ class MainGUI:
             "- Originals: HoleID_From-To_Original.ext"
         )
         DialogHelper.show_message(self.root, "File Structure Information", info_message, message_type="info")
+
+    def _open_embedding_dialog(self):
+        """Open the embedding training dialog."""
+        try:
+            dialog = EmbeddingTrainingDialog(self.root, self.gui_manager, self.file_manager)
+        except Exception as e:
+            self.logger.error(f"Error opening embedding dialog: {str(e)}")
+            DialogHelper.show_message(
+                self.root,
+                self.t("Error"),
+                self.t("Failed to open embedding tool") + f"\n{str(e)}",
+                message_type="error",
+            )
 
     def _show_blur_help(self):
         """Show help information about blur detection."""

--- a/src/processing/__init__.py
+++ b/src/processing/__init__.py
@@ -11,6 +11,12 @@ from processing.drillhole_data_visualizer import (
     PlotType,
     PlotConfig
 )
+from processing.embedding_trainer import (
+    generate_embeddings,
+    plot_embeddings,
+    EmbeddingModel,
+    ImageTabularDataset,
+)
 # ===================================================
 # INSERT: export pipeline helpers
 from processing.pipeline import (

--- a/src/processing/embedding_trainer.py
+++ b/src/processing/embedding_trainer.py
@@ -1,0 +1,104 @@
+"""
+processing/embedding_trainer.py
+
+Utilities for generating neural network embeddings from images and
+tabular data. Provides a simple dataset class, embedding model and
+helper functions for producing and visualising embeddings.
+"""
+
+from typing import Sequence, Optional
+
+import numpy as np
+import torch
+from torch import nn
+from torch.utils.data import Dataset, DataLoader
+from torchvision import models, transforms
+from PIL import Image
+
+
+class ImageTabularDataset(Dataset):
+    """Dataset combining image files with accompanying tabular values."""
+
+    def __init__(self, image_paths: Sequence[str], tabular_values: Sequence[Sequence[float]], transform: Optional[transforms.Compose] = None) -> None:
+        self.image_paths = list(image_paths)
+        self.tabular_values = [list(v) for v in tabular_values]
+        self.transform = transform or transforms.ToTensor()
+
+    def __len__(self) -> int:
+        return len(self.image_paths)
+
+    def __getitem__(self, idx: int):
+        image = Image.open(self.image_paths[idx]).convert("RGB")
+        image = self.transform(image)
+        tabular = torch.tensor(self.tabular_values[idx], dtype=torch.float32)
+        return image, tabular
+
+
+class EmbeddingModel(nn.Module):
+    """Simple model that combines ResNet features with tabular features."""
+
+    def __init__(self, tabular_dim: int) -> None:
+        super().__init__()
+        base = models.resnet18(weights=models.ResNet18_Weights.DEFAULT)
+        self.cnn = nn.Sequential(*list(base.children())[:-1])
+        self.tabular_net = nn.Sequential(
+            nn.Linear(tabular_dim, 16),
+            nn.ReLU(),
+            nn.Linear(16, 16),
+        )
+
+    def forward(self, img: torch.Tensor, tabular: torch.Tensor) -> torch.Tensor:
+        x1 = self.cnn(img).squeeze()
+        x2 = self.tabular_net(tabular)
+        return torch.cat((x1, x2), dim=1)
+
+
+def generate_embeddings(image_paths: Sequence[str], tabular_values: Sequence[Sequence[float]], batch_size: int = 16, device: Optional[torch.device] = None) -> np.ndarray:
+    """Generate embeddings for provided images and tabular values."""
+
+    device = device or torch.device("cpu")
+    transform = transforms.Compose([
+        transforms.Resize((224, 224)),
+        transforms.ToTensor(),
+        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+    ])
+
+    dataset = ImageTabularDataset(image_paths, tabular_values, transform)
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=False)
+    model = EmbeddingModel(len(tabular_values[0])).to(device).eval()
+
+    embeddings = []
+    with torch.no_grad():
+        for imgs, tabs in loader:
+            imgs = imgs.to(device)
+            tabs = tabs.to(device)
+            out = model(imgs, tabs)
+            embeddings.append(out.cpu().numpy())
+
+    return np.vstack(embeddings)
+
+
+def plot_embeddings(embeddings: np.ndarray, save_path: str, gui_manager=None) -> None:
+    """Plot embeddings using PCA and save the figure."""
+
+    from sklearn.decomposition import PCA
+    import matplotlib.pyplot as plt
+
+    pca = PCA(n_components=2)
+    reduced = pca.fit_transform(embeddings)
+
+    plt.style.use('dark_background')
+    if gui_manager:
+        colors = gui_manager.theme_colors
+        plt.rcParams['text.color'] = colors['text']
+        plt.rcParams['axes.labelcolor'] = colors['text']
+        plt.rcParams['axes.edgecolor'] = colors['text']
+        plt.rcParams['axes.facecolor'] = colors['background']
+        plt.rcParams['figure.facecolor'] = colors['background']
+    plt.figure(figsize=(10, 6))
+    plt.scatter(reduced[:, 0], reduced[:, 1], s=20, alpha=0.7)
+    plt.title('Embedding Projection (PCA)')
+    plt.tight_layout()
+    plt.savefig(save_path)
+    plt.close()
+


### PR DESCRIPTION
## Summary
- add `EmbeddingTrainingDialog` for GUI-based embedding generation
- provide `embedding_trainer` utilities for image/tabular embeddings
- expose new dialog and functions in package `__init__` files
- add helper `save_embedding_plot` to `FileManager`
- include menu button and handler in `MainGUI`

## Testing
- `python -m compileall src`

------
https://chatgpt.com/codex/tasks/task_e_685b69f732048320946f6d1bdde24166