### PR TITLE
Add GUI visualization tests

### DIFF
--- a/src/tests/synthetic_data.py
+++ b/src/tests/synthetic_data.py
@@ -1,0 +1,66 @@
+import cv2
+import numpy as np
+from typing import Dict, Tuple, Any
+
+
+def generate_test_tray_image(config: Dict[str, Any], width: int = 800, height: int = 400) -> Tuple[np.ndarray, Dict[int, np.ndarray]]:
+    """Generate a synthetic chip tray image with ArUco markers for testing.
+
+    This helper creates a blank white image and draws a subset of ArUco markers
+    for the corner and compartment IDs defined in ``config``.
+
+    Args:
+        config: Configuration dictionary containing ``aruco_dict_type``,
+            ``corner_marker_ids`` and ``compartment_marker_ids``.
+        width: Width of the generated image in pixels.
+        height: Height of the generated image in pixels.
+
+    Returns:
+        Tuple of ``(image, markers)`` where ``image`` is the generated BGR image
+        and ``markers`` is a dictionary mapping marker IDs to their corner
+        coordinates.
+    """
+    dictionary_name = config.get("aruco_dict_type", "DICT_4X4_1000")
+    aruco_dict = cv2.aruco.getPredefinedDictionary(getattr(cv2.aruco, dictionary_name))
+
+    # Start with a white background
+    image = np.full((height, width, 3), 255, dtype=np.uint8)
+    markers: Dict[int, np.ndarray] = {}
+
+    marker_size = 50
+    margin = 20
+
+    # Place corner markers in each corner
+    corner_ids = config.get("corner_marker_ids", [0, 1, 2, 3])
+    corner_positions = [
+        (margin, margin),
+        (width - margin - marker_size, margin),
+        (width - margin - marker_size, height - margin - marker_size),
+        (margin, height - margin - marker_size),
+    ]
+    for idx, (x, y) in enumerate(corner_positions):
+        marker_id = corner_ids[idx % len(corner_ids)]
+        marker_img = cv2.aruco.generateImageMarker(aruco_dict, marker_id, marker_size)
+        image[y : y + marker_size, x : x + marker_size] = cv2.cvtColor(marker_img, cv2.COLOR_GRAY2BGR)
+        corners = np.array(
+            [[x, y], [x + marker_size, y], [x + marker_size, y + marker_size], [x, y + marker_size]],
+            dtype=np.float32,
+        )
+        markers[marker_id] = corners
+
+    # Place a few compartment markers along the middle
+    comp_ids = config.get("compartment_marker_ids", [])
+    if comp_ids:
+        step = (width - 2 * margin - marker_size) // len(comp_ids[:4])
+        y = height // 2 - marker_size // 2
+        for i, marker_id in enumerate(comp_ids[:4]):
+            x = margin + i * step
+            marker_img = cv2.aruco.generateImageMarker(aruco_dict, marker_id, marker_size)
+            image[y : y + marker_size, x : x + marker_size] = cv2.cvtColor(marker_img, cv2.COLOR_GRAY2BGR)
+            corners = np.array(
+                [[x, y], [x + marker_size, y], [x + marker_size, y + marker_size], [x, y + marker_size]],
+                dtype=np.float32,
+            )
+            markers[marker_id] = corners
+
+    return image, markers

--- a/src/tests/test_aruco_manager.py
+++ b/src/tests/test_aruco_manager.py
@@ -1,0 +1,41 @@
+import tkinter as tk
+from PIL import Image, ImageTk
+import cv2
+import json
+
+from core.visualization_manager import VisualizationManager
+from processing.aruco_manager import ArucoManager
+from tests.synthetic_data import generate_test_tray_image
+
+
+def _draw_analysis(image, markers, boundaries):
+    viz = image.copy()
+    for mid, corners in markers.items():
+        pts = corners.astype(int).reshape((-1, 1, 2))
+        cv2.polylines(viz, [pts], True, (0, 0, 255), 2)
+    for x1, y1, x2, y2 in boundaries:
+        cv2.line(viz, (x1, y1), (x2, y2), (0, 255, 0), 2)
+    return viz
+
+
+def run():
+    with open('src/config.json', 'r') as f:
+        config = json.load(f)
+    image, _ = generate_test_tray_image(config)
+
+    aruco = ArucoManager(config)
+    markers = aruco.detect_markers(image)
+    analysis = aruco.analyze_compartment_boundaries(image, markers, smart_cropping=False)
+
+    viz = _draw_analysis(image, markers, analysis.get('boundaries', []))
+
+    root = tk.Tk()
+    root.title('ArucoManager Test')
+    photo = ImageTk.PhotoImage(image=Image.fromarray(cv2.cvtColor(viz, cv2.COLOR_BGR2RGB)))
+    label = tk.Label(root, image=photo)
+    label.pack()
+    root.mainloop()
+
+
+if __name__ == '__main__':
+    run()

--- a/src/tests/test_compartment_registration_dialog.py
+++ b/src/tests/test_compartment_registration_dialog.py
@@ -1,0 +1,45 @@
+import tkinter as tk
+import json
+import cv2
+from PIL import Image, ImageTk
+
+from core.file_manager import FileManager
+from gui.gui_manager import GUIManager
+from gui.dialog_helper import DialogHelper
+from gui.compartment_registration_dialog import CompartmentRegistrationDialog
+from processing.aruco_manager import ArucoManager
+from tests.synthetic_data import generate_test_tray_image
+
+
+def run():
+    with open('src/config.json', 'r') as f:
+        config = json.load(f)
+    image, _ = generate_test_tray_image(config)
+
+    aruco = ArucoManager(config)
+    markers = aruco.detect_markers(image)
+    analysis = aruco.analyze_compartment_boundaries(image, markers, smart_cropping=False)
+
+    root = tk.Tk()
+    fm = FileManager()
+    gm = GUIManager(fm)
+    DialogHelper.set_gui_manager(gm)
+
+    dlg = CompartmentRegistrationDialog(
+        parent=root,
+        image=image,
+        detected_boundaries=analysis.get('boundaries', []),
+        markers=markers,
+        boundary_analysis=analysis,
+        gui_manager=gm,
+        file_manager=fm,
+        metadata={'hole_id': 'TEST1', 'depth_from': 0, 'depth_to': 10},
+        vertical_constraints=analysis.get('vertical_constraints'),
+        marker_to_compartment=analysis.get('marker_to_compartment'),
+    )
+
+    root.mainloop()
+
+
+if __name__ == '__main__':
+    run()

--- a/src/tests/test_visualization_manager.py
+++ b/src/tests/test_visualization_manager.py
@@ -1,0 +1,42 @@
+import tkinter as tk
+from PIL import Image, ImageTk
+import cv2
+
+from core.visualization_manager import VisualizationManager
+from tests.synthetic_data import generate_test_tray_image
+import json
+
+
+def _draw_markers(image, markers):
+    """Utility draw function for VisualizationManager."""
+    viz = image.copy()
+    for mid, corners in markers.items():
+        pts = corners.astype(int).reshape((-1, 1, 2))
+        cv2.polylines(viz, [pts], True, (0, 0, 255), 2)
+        center = tuple(corners.mean(axis=0).astype(int))
+        cv2.putText(viz, str(mid), center, cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 0, 255), 2)
+    return viz
+
+
+def run():
+    """Open a window showing VisualizationManager output."""
+    with open('src/config.json', 'r') as f:
+        config = json.load(f)
+    image, markers = generate_test_tray_image(config)
+
+    manager = VisualizationManager()
+    manager.load_image(image, 'synthetic.png')
+    manager.create_working_copy()
+
+    viz = manager.create_visualization('working', 'markers', _draw_markers, markers=markers)
+
+    root = tk.Tk()
+    root.title('VisualizationManager Test')
+    photo = ImageTk.PhotoImage(image=Image.fromarray(cv2.cvtColor(viz, cv2.COLOR_BGR2RGB)))
+    label = tk.Label(root, image=photo)
+    label.pack()
+    root.mainloop()
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
## Summary
- add a helper for generating synthetic chip tray images with ArUco markers
- add a test script for `VisualizationManager`
- add a test script for `ArucoManager`
- add a test script for `CompartmentRegistrationDialog`

## Testing
- `python -m compileall src`

------
https://chatgpt.com/codex/tasks/task_e_685e3f128f58832086a0511ed8dcdbb8